### PR TITLE
Add SetFlag() function to set flags on/off via boolean.

### DIFF
--- a/EnumUtil/EnumCompiledCache.cs
+++ b/EnumUtil/EnumCompiledCache.cs
@@ -71,6 +71,26 @@ namespace EnumUtilities
                 .Compile();
         }
 
+        static Func<T, T> BitwiseUnaryOperator(ExpressionType expressionType)
+        {
+            var val = Expression.Parameter(typeof(T));
+
+            // Convert from Enum to Enum’s underlying type (byte, int, long, …)
+            // to allow bitwise functions to work
+            var valConverted = Expression.Convert(val, Enum.GetUnderlyingType(typeof(T)));
+
+            var unaryExpression =
+                Expression.MakeUnary(
+                    expressionType,
+                    valConverted,
+                    null);
+
+            // Convert back to Enum
+            var backToEnumType = Expression.Convert(unaryExpression, typeof(T));
+            return Expression.Lambda<Func<T, T>>(backToEnumType, val)
+                .Compile();
+        }
+
         private static Func<T, T, T> GenerateBitwiseOr()
         {
             return BitwiseOperator(ExpressionType.Or);
@@ -86,6 +106,9 @@ namespace EnumUtilities
             return BitwiseOperator(ExpressionType.ExclusiveOr);
         }
 
+        static Func<T, T> GenerateBitwiseNot()
+            => BitwiseUnaryOperator(ExpressionType.Not);
+
         #endregion
 
         public static readonly Func<T, T, T> BitwiseOr = GenerateBitwiseOr();
@@ -93,6 +116,8 @@ namespace EnumUtilities
         public static readonly Func<T, T, T> BitwiseAnd = GenerateBitwiseAnd();
 
         public static readonly Func<T, T, T> BitwiseExclusiveOr = GenerateBitwiseExclusiveOr();
+
+        public static readonly Func<T, T> BitwiseNot = GenerateBitwiseNot();
 
         public static readonly Func<T, T, bool> HasFlag = GenerateHasFlag();
 

--- a/EnumUtil/EnumCompiledCache.cs
+++ b/EnumUtil/EnumCompiledCache.cs
@@ -71,7 +71,7 @@ namespace EnumUtilities
                 .Compile();
         }
 
-        static Func<T, T> BitwiseUnaryOperator(ExpressionType expressionType)
+        private static Func<T, T> BitwiseUnaryOperator(ExpressionType expressionType)
         {
             var val = Expression.Parameter(typeof(T));
 
@@ -106,7 +106,7 @@ namespace EnumUtilities
             return BitwiseOperator(ExpressionType.ExclusiveOr);
         }
 
-        static Func<T, T> GenerateBitwiseNot()
+        private static Func<T, T> GenerateBitwiseNot()
             => BitwiseUnaryOperator(ExpressionType.Not);
 
         #endregion

--- a/EnumUtil/EnumUtilBase.cs
+++ b/EnumUtil/EnumUtilBase.cs
@@ -105,11 +105,17 @@ namespace EnumUtilities
         public static string[] GetNames<T>() where T : struct, E
             => Enum.GetNames(typeof(T));
 
-        public static T SetFlag<T>(T value, T flag, bool on = true) where T : struct, E
-            => on ? BitwiseOr(value, flag) : BitwiseAnd(value, BitwiseNot(flag));
+        public static T SetFlag<T>(T value, T flag) where T : struct, E
+            => BitwiseOr(value, flag);
 
         public static T UnsetFlag<T>(T value, T flag) where T : struct, E
-            => SetFlag(value, flag, false);
+            => BitwiseAnd(value, BitwiseNot(flag));
+
+        public static T ToggleFlag<T>(T value, T flag) where T : struct, E
+            => BitwiseExclusiveOr(value, flag);
+
+        public static T ToggleFlag<T>(T value, T flag, bool flagSet) where T : struct, E
+            => (flagSet ? (Func<T, T, T>)SetFlag : UnsetFlag)(value, flag);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParse<T>(string value, out T result) where T : struct, E

--- a/EnumUtil/EnumUtilBase.cs
+++ b/EnumUtil/EnumUtilBase.cs
@@ -32,6 +32,10 @@ namespace EnumUtilities
             => EnumCompiledCache<T>.BitwiseExclusiveOr(left, right);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T BitwiseNot<T>(T value) where T : struct, E
+            => EnumCompiledCache<T>.BitwiseNot(value);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool HasFlag<T>(T value, T flag) where T : struct, E
             => EnumCompiledCache<T>.HasFlag(value, flag);
 
@@ -100,6 +104,9 @@ namespace EnumUtilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string[] GetNames<T>() where T : struct, E
             => Enum.GetNames(typeof(T));
+
+        public static T SetFlag<T>(T value, T flag, bool on = true) where T : struct, E
+            => on ? BitwiseOr(value, flag) : BitwiseAnd(value, BitwiseNot(flag));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParse<T>(string value, out T result) where T : struct, E

--- a/EnumUtil/EnumUtilBase.cs
+++ b/EnumUtil/EnumUtilBase.cs
@@ -108,6 +108,9 @@ namespace EnumUtilities
         public static T SetFlag<T>(T value, T flag, bool on = true) where T : struct, E
             => on ? BitwiseOr(value, flag) : BitwiseAnd(value, BitwiseNot(flag));
 
+        public static T UnsetFlag<T>(T value, T flag) where T : struct, E
+            => SetFlag(value, flag, false);
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParse<T>(string value, out T result) where T : struct, E
             => Enum.TryParse(value, out result);

--- a/EnumUtilTests/UnitTests.cs
+++ b/EnumUtilTests/UnitTests.cs
@@ -259,5 +259,23 @@ namespace EnumUtilTests
                 Assert.IsTrue(EnumUtilBase<T>.TryParse(name, true, out value));
             }
         }
+
+        [TestMethod]
+        public void SetFlag()
+        {
+            var value = default(FlagsEnum);
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.SetFlag(value, FlagsEnum.One));
+            Assert.AreEqual(FlagsEnum.Two, EnumUtil.SetFlag(value, FlagsEnum.Two));
+
+            Assert.AreEqual(default(FlagsEnum), EnumUtil.SetFlag(value, FlagsEnum.One, false));
+            Assert.AreEqual(default(FlagsEnum), EnumUtil.SetFlag(value, FlagsEnum.Two, false));
+
+            value = FlagsEnum.One;
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.SetFlag(value, FlagsEnum.One));
+            Assert.AreEqual(FlagsEnum.One | FlagsEnum.Two, EnumUtil.SetFlag(value, FlagsEnum.Two));
+
+            Assert.AreEqual(default(FlagsEnum), EnumUtil.SetFlag(value, FlagsEnum.One, false));
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.SetFlag(value, FlagsEnum.Two, false));
+        }
     }
 }

--- a/EnumUtilTests/UnitTests.cs
+++ b/EnumUtilTests/UnitTests.cs
@@ -315,6 +315,17 @@ namespace EnumUtilTests
 
             Assert.AreEqual(default(FlagsEnum), EnumUtil.ToggleFlag(value, FlagsEnum.One, false));
             Assert.AreEqual(FlagsEnum.One, EnumUtil.ToggleFlag(value, FlagsEnum.Two, false));
+
+            // Starting with two flags.
+            value = FlagsEnum.One | FlagsEnum.Two;
+            Assert.AreEqual(FlagsEnum.Two, EnumUtil.ToggleFlag(value, FlagsEnum.One));
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.ToggleFlag(value, FlagsEnum.Two));
+
+            Assert.AreEqual(FlagsEnum.One | FlagsEnum.Two, EnumUtil.ToggleFlag(value, FlagsEnum.One, true));
+            Assert.AreEqual(FlagsEnum.One | FlagsEnum.Two, EnumUtil.ToggleFlag(value, FlagsEnum.Two, true));
+
+            Assert.AreEqual(FlagsEnum.Two, EnumUtil.ToggleFlag(value, FlagsEnum.One, false));
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.ToggleFlag(value, FlagsEnum.Two, false));
         }
     }
 }

--- a/EnumUtilTests/UnitTests.cs
+++ b/EnumUtilTests/UnitTests.cs
@@ -267,15 +267,9 @@ namespace EnumUtilTests
             Assert.AreEqual(FlagsEnum.One, EnumUtil.SetFlag(value, FlagsEnum.One));
             Assert.AreEqual(FlagsEnum.Two, EnumUtil.SetFlag(value, FlagsEnum.Two));
 
-            Assert.AreEqual(default(FlagsEnum), EnumUtil.SetFlag(value, FlagsEnum.One, false));
-            Assert.AreEqual(default(FlagsEnum), EnumUtil.SetFlag(value, FlagsEnum.Two, false));
-
             value = FlagsEnum.One;
             Assert.AreEqual(FlagsEnum.One, EnumUtil.SetFlag(value, FlagsEnum.One));
             Assert.AreEqual(FlagsEnum.One | FlagsEnum.Two, EnumUtil.SetFlag(value, FlagsEnum.Two));
-
-            Assert.AreEqual(default(FlagsEnum), EnumUtil.SetFlag(value, FlagsEnum.One, false));
-            Assert.AreEqual(FlagsEnum.One, EnumUtil.SetFlag(value, FlagsEnum.Two, false));
         }
 
         [TestMethod]
@@ -295,6 +289,32 @@ namespace EnumUtilTests
             value = FlagsEnum.One | FlagsEnum.Two;
             Assert.AreEqual(FlagsEnum.Two, EnumUtil.UnsetFlag(value, FlagsEnum.One));
             Assert.AreEqual(FlagsEnum.One, EnumUtil.UnsetFlag(value, FlagsEnum.Two));
+        }
+
+        [TestMethod]
+        public void ToggleFlag()
+        {
+            var value = default(FlagsEnum);
+            // Toggling will effectively set when unset.
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.ToggleFlag(value, FlagsEnum.One));
+            Assert.AreEqual(FlagsEnum.Two, EnumUtil.ToggleFlag(value, FlagsEnum.Two));
+
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.ToggleFlag(value, FlagsEnum.One, true));
+            Assert.AreEqual(FlagsEnum.Two, EnumUtil.ToggleFlag(value, FlagsEnum.Two, true));
+
+            Assert.AreEqual(default(FlagsEnum), EnumUtil.ToggleFlag(value, FlagsEnum.One, false));
+            Assert.AreEqual(default(FlagsEnum), EnumUtil.ToggleFlag(value, FlagsEnum.Two, false));
+
+            value = FlagsEnum.One;
+            // Toggling will of course unset if already set.
+            Assert.AreEqual(default(FlagsEnum), EnumUtil.ToggleFlag(value, FlagsEnum.One));
+            Assert.AreEqual(FlagsEnum.One | FlagsEnum.Two, EnumUtil.ToggleFlag(value, FlagsEnum.Two));
+
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.ToggleFlag(value, FlagsEnum.One, true));
+            Assert.AreEqual(FlagsEnum.One | FlagsEnum.Two, EnumUtil.ToggleFlag(value, FlagsEnum.Two, true));
+
+            Assert.AreEqual(default(FlagsEnum), EnumUtil.ToggleFlag(value, FlagsEnum.One, false));
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.ToggleFlag(value, FlagsEnum.Two, false));
         }
     }
 }

--- a/EnumUtilTests/UnitTests.cs
+++ b/EnumUtilTests/UnitTests.cs
@@ -277,5 +277,24 @@ namespace EnumUtilTests
             Assert.AreEqual(default(FlagsEnum), EnumUtil.SetFlag(value, FlagsEnum.One, false));
             Assert.AreEqual(FlagsEnum.One, EnumUtil.SetFlag(value, FlagsEnum.Two, false));
         }
+
+        [TestMethod]
+        public void UnsetFlag()
+        {
+            // Removing flags from empty value is no-op.
+            var value = default(FlagsEnum);
+            Assert.AreEqual(value, EnumUtil.UnsetFlag(value, FlagsEnum.One));
+            Assert.AreEqual(value, EnumUtil.UnsetFlag(value, FlagsEnum.Two));
+
+            // Starting with one flag.
+            value = FlagsEnum.One;
+            Assert.AreEqual(default(FlagsEnum), EnumUtil.UnsetFlag(value, FlagsEnum.One));
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.UnsetFlag(value, FlagsEnum.Two));
+
+            // Starting with two flags.
+            value = FlagsEnum.One | FlagsEnum.Two;
+            Assert.AreEqual(FlagsEnum.Two, EnumUtil.UnsetFlag(value, FlagsEnum.One));
+            Assert.AreEqual(FlagsEnum.One, EnumUtil.UnsetFlag(value, FlagsEnum.Two));
+        }
     }
 }


### PR DESCRIPTION
Hi,

I was looking at making some code I was touching more readable/less error prone by taking a flags-enabled enum value, a particular flag, and a boolean to either set the bits for that flag on or off as a logical operation. I’m not sure if your library is attempting to solve that sort of problem, but I did find that building such a method on top of your idiom of dynamically compiling away `GetUnderlyingType()` calls provided a good starting point.

This adds a `BitwiseNot()` (for when turning the flag off / setting `on: false`) and `T SetFlag(T value, T flag, bool on = true)` the current way I envision this working.

If you consider incorporating this change, may you also consider publishing an assembly-oriented nuget package for this library? I’d like to use it and `SetFlag()` while letting nuget deal with the sort of thing it’s meant to deal with—referencing external libraries with reusable code that shouldn’t have to be recreated in every project.
