### PR TITLE
Add typesafe EnumUtil.IsDefined().

### DIFF
--- a/EnumUtil/EnumUtilBase.cs
+++ b/EnumUtil/EnumUtilBase.cs
@@ -86,6 +86,22 @@ namespace EnumUtilities
             => EnumCompiledCache<T>.HasFlag(value, flag);
 
         /// <summary>
+        /// Checks if the value is valid for the enum.
+        /// </summary>
+        /// <typeparam name="T">An enumeration type</typeparam>
+        /// <param name="value">An enumeration value</param>
+        /// <returns>
+        /// true if <paramref name="value"/> is valid for <typeparamref name="T"/>.
+        /// </returns>
+        /// <remarks>
+        ///   <para>
+        ///     For the sake of providing a typesafe API alternative to <c>Enum.IsDefined(typeof(T), value)</c>.
+        ///   </para>
+        /// </remarks>
+        public static bool IsDefined<T>(T value) where T : struct, E
+            => Enum.IsDefined(typeof(T), value);
+
+        /// <summary>
         /// Retrieves a specific attribute on the enumeration type
         /// </summary>
         /// <typeparam name="Y">Attribute to Retrieve</typeparam>

--- a/EnumUtilTests/UnitTests.cs
+++ b/EnumUtilTests/UnitTests.cs
@@ -244,6 +244,9 @@ namespace EnumUtilTests
                 Assert.IsFalse(EnumUtilBase<E>.HasFlagsAttribute<T>());
                 Assert.IsFalse(EnumUtilBase<E>.HasAttribute<FlagsAttribute, T>());
 
+                Assert.IsTrue(EnumUtilBase<E>.IsDefined(value));
+                Assert.IsFalse(EnumUtilBase<E>.IsDefined(default(T)));
+
                 Assert.AreEqual(name, EnumUtilBase<E>.GetName(value));
                 Assert.AreEqual(value, EnumUtilBase<E>.Parse<T>(name));
 


### PR DESCRIPTION
Like EnumUtil.Parse(), this is a convenience wrapper enabling cleaner
code compared to the framework-provided method.

I think this would be a natural addition to EnumUtilities. Please let me know if I should format the patch differently or feel free to recode it directly yourself as I think it’s a trivial change ;-).
