### PR TITLE
Add FlagwiseNot().

### DIFF
--- a/EnumUtilTests/Enums/OverlappingValuesFlagsEnum.cs
+++ b/EnumUtilTests/Enums/OverlappingValuesFlagsEnum.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace EnumUtilTests.Enums
+{
+    [Flags]
+    [Description("Flags Enum with extra overlapping values")]
+    public enum OverlappingValuesFlagsEnum
+    {
+        [Description("0000")]
+        Zero = 0,
+        [Description("0001")]
+        One = 1,
+        [Description("0010")]
+        Two = 2,
+        [Description("0100")]
+        Four = 4,
+        [Description("1000")]
+        Eight = 8,
+        [Description("0101")]
+        OneOrFour = 5,
+        [Description("1111")]
+        All = 15,
+    }
+}

--- a/EnumUtilTests/UnitTests.cs
+++ b/EnumUtilTests/UnitTests.cs
@@ -232,6 +232,22 @@ namespace EnumUtilTests
         }
 
         [TestMethod]
+        public void FlagwiseNot()
+        {
+            var value = FlagsEnum.One | FlagsEnum.Eight;
+            Assert.AreEqual(FlagsEnum.Two | FlagsEnum.Four, EnumUtil<FlagsEnum>.FlagwiseNot(value));
+
+            var overlappingValue = OverlappingValuesFlagsEnum.OneOrFour;
+            Assert.AreEqual(OverlappingValuesFlagsEnum.Two | OverlappingValuesFlagsEnum.Eight, EnumUtil<OverlappingValuesFlagsEnum>.FlagwiseNot(overlappingValue));
+            Assert.AreEqual(OverlappingValuesFlagsEnum.All, EnumUtil<OverlappingValuesFlagsEnum>.FlagwiseNot(default));
+            Assert.AreEqual(EnumUtil<OverlappingValuesFlagsEnum>.FlagwiseNot(default), OverlappingValuesFlagsEnum.All);
+            foreach (var anotherOverlappingValue in EnumUtil<OverlappingValuesFlagsEnum>.GetValues())
+            {
+                Assert.AreEqual(anotherOverlappingValue, EnumUtil<OverlappingValuesFlagsEnum>.FlagwiseNot(EnumUtil<OverlappingValuesFlagsEnum>.FlagwiseNot(anotherOverlappingValue)));
+            }
+        }
+
+        [TestMethod]
         public void SetFlag()
         {
             var value = default(FlagsEnum);

--- a/EnumUtilities/EnumUtil.cs
+++ b/EnumUtilities/EnumUtil.cs
@@ -144,6 +144,13 @@ namespace EnumUtilities
             => bitwiseNot(value);
 
         /// <summary>
+        /// Invert the flags (setting all single-bit flags which are not set and unsetting all single-bit flags which are set).
+        /// </summary>
+        /// <returns><c>value</c> with all flags inverted</returns>
+        public static TEnum FlagwiseNot(TEnum value)
+            => flagwiseNot(value);
+
+        /// <summary>
         /// Checks whether a flag exists.
         /// This function does not check for <c>FlagsAttribute</c>.
         /// </summary>


### PR DESCRIPTION
Convenience to invert all flags on an enum.

Fixes #10.